### PR TITLE
Data Model Integration Test Fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,8 +94,7 @@ def test_space(test_config, cognite_client: CogniteClient):
         space = cognite_client.data_modeling.spaces.apply(new_space)
     else: # Ensure there aren't existing data models
         data_model_list = cognite_client.data_modeling.data_models.list(space=space_id)
-        for data_model in data_model_list:
-            cognite_client.data_modeling.data_models.delete((space_id, data_model.external_id, data_model.version))
+        assert len(data_model_list) == 0, "Space should not have existing data models, please remove models/views/containers before testing"
     yield space
     cognite_client.data_modeling.spaces.delete(spaces=[space_id])
     

--- a/tests/integration/integration_steps/service_steps.py
+++ b/tests/integration/integration_steps/service_steps.py
@@ -12,6 +12,6 @@ def stop_replicator():
     # Stop the replicator service
     pass
 
-def setup_data_model_sync():
-    # Setup data model sync service between CDF and Fabric
+def run_data_model_sync():
+    # Run data model sync service between CDF and Fabric
     pass

--- a/tests/integration/resources/movie_model.graphql
+++ b/tests/integration/resources/movie_model.graphql
@@ -1,0 +1,24 @@
+type Person {
+    name: String!
+    birthYear: Int
+    roles: [Role]
+}
+
+interface Role{
+    movies: [Movie]
+    person: Person
+}
+
+type Actor implements Role {
+    movies: [Movie]
+    wonOscar: Boolean
+    person: Person
+}
+
+type Movie{
+    title: String!
+    actors: [Actor]
+    releaseYear: Int
+    runTimeMinutes: Float
+    meta: JSONObject
+}

--- a/tests/integration/test_config.yaml
+++ b/tests/integration/test_config.yaml
@@ -35,5 +35,5 @@ subscriptions:
 
 # sync data model
 data_modeling:
-    - space: cc_plant
+    - space: IntegrationTestSpace
       lakehouse_abfss_prefix: ${LAKEHOUSE_ABFSS_PREFIX}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,8 +1,8 @@
 import pytest
-from integration_steps.cdf_steps import push_data_to_cdf
+from integration_steps.cdf_steps import push_data_to_cdf, create_data_model_in_cdf, update_data_model_in_cdf
 from integration_steps.time_series_generation import TimeSeriesGeneratorArgs
-from integration_steps.fabric_steps import assert_timeseries_data_in_fabric
-from integration_steps.service_steps import run_replicator
+from integration_steps.fabric_steps import assert_timeseries_data_in_fabric, assert_data_model_in_fabric, assert_data_model_update
+from integration_steps.service_steps import run_replicator, run_data_model_sync
 
 
 # Test for Timeseries data integration service
@@ -22,3 +22,23 @@ def test_timeseries_data_integration_service(cognite_client, test_replicator, la
     # Assert timeseries data is populated in a Fabric lakehouse
     for ts_external_id, data_points in pushed_data.items():
         assert_timeseries_data_in_fabric(ts_external_id, data_points, lakehouse_timeseries_path, azure_credential)
+
+# Test for data model sync service
+# @pytest.mark.skip("Skipping test", allow_module_level=True)
+def test_data_model_sync_service_creation(test_space, test_dml, edge_table_name, view_tables):
+    # Create a data model in CDF
+    create_data_model_in_cdf()
+    # Run data model sync service between CDF and Fabric
+    run_data_model_sync()
+    # Assert the data model is populated in a Fabric lakehouse
+    assert_data_model_in_fabric()
+
+# @pytest.mark.skip("Skipping test", allow_module_level=True)
+def test_data_model_sync_service_update(test_model, edge_table_name, view_tables):
+    # Run data model sync service between CDF and Fabric
+    run_data_model_sync()
+    # Update a data model in CDF and run data model sync
+    update_data_model_in_cdf()
+    run_data_model_sync()
+    # Assert the data model changes including versions and last updated timestamps are propagated to a Fabric lakehouse
+    assert_data_model_update()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -25,7 +25,7 @@ def test_timeseries_data_integration_service(cognite_client, test_replicator, la
 
 # Test for data model sync service
 # @pytest.mark.skip("Skipping test", allow_module_level=True)
-def test_data_model_sync_service_creation(test_space, test_dml, edge_table_name, view_tables):
+def test_data_model_sync_service_creation(test_model, edge_table_path, instance_table_paths, cognite_client):
     # Create a data model in CDF
     create_data_model_in_cdf()
     # Run data model sync service between CDF and Fabric
@@ -34,7 +34,7 @@ def test_data_model_sync_service_creation(test_space, test_dml, edge_table_name,
     assert_data_model_in_fabric()
 
 # @pytest.mark.skip("Skipping test", allow_module_level=True)
-def test_data_model_sync_service_update(test_model, edge_table_name, view_tables):
+def test_data_model_sync_service_update(test_model, edge_table_path, instance_table_paths, cognite_client):
     # Run data model sync service between CDF and Fabric
     run_data_model_sync()
     # Update a data model in CDF and run data model sync


### PR DESCRIPTION
Adds the following fixtures to the integration tests to set up for the data model tests:

- Integration test space
- Data model dml (simplified version of Cognite's [test graphql](https://github.com/cognitedata/cognite-sdk-python/blob/master/tests/tests_integration/test_api/test_data_modeling/resources/movie_model.graphql))
- Creation of data model in CDF
- Table names for Fabric Lakehouse tables created by replicator

Future PR's will be added for the CDF, service and Fabric steps in the test stubs.